### PR TITLE
Add TypeScript type definition for `MathJax` component and props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+package-lock.json
+yarn.lock

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+import { ReactElement } from "react";
+import { XmlProps } from "react-native-svg";
+
+export type MathJaxProps = Omit<XmlProps, "xml"> & {
+  color?: string;
+  fontSize?: number;
+  children?: string;
+};
+
+export default function MathJax(props: MathJaxProps): ReactElement;

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "mathjax-svg"
   ],
   "author": "Nahrae <jinnahrae@gmail.com>",
-  "dependencies": {
-
-  },
-  "peerDependencies": {
-  },
+  "dependencies": {},
+  "peerDependencies": {},
   "devDependencies": {
+    "@types/react": "^17.0.11",
+    "@types/react-native": "^0.64.10",
+    "react-native-svg": "^12.1.1",
+    "typescript": "^4.3.4"
   },
   "bugs": {
     "url": "https://github.com/railsjack/react-native-mathjax-svg.git"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "noEmit": true,
+    "strict": true
+  },
+  "files": ["index.d.ts"]
+}


### PR DESCRIPTION
Previously the empty `index.d.ts` file caused the following compiler
error when importing the `react-native-mathjax-svg` package into a
TypeScript module:

> File '/[...]/node_modules/react-native-mathjax-svg/index.d.ts' is not
> a module. ts(2306)

The PR fixes that by adding a valid definition for the `MathJax`
component and props.

Because all the props are eventually forwarded to the `SvgFromXml`
component, is component inherits all of the props from that component
except for the `xml` prop which is set internally based on the `content`
prop.

As documented in the README, the component also has a `fontSize` prop
(which does not exist in the `SvgFromXml` props), a `color` prop (which
I've conservatively assumed must be a string), and takes the LaTeX
markup as its `children`. Based on the JavaScript code, all these props
appear to have defaults and so I've marked them all as optional.

In order to be able to verify the typings with the TypeScript compiler
I have also:

+ Added dev dependencies on `react-native-svg`, TypeScript and the type
  definitions for React and React Native
+ Added a `.gitignore` file so that the dev dependencies and lock files
  generated by `npm` and `yarn` are not committed to the repo
+ Added a minimal `tsconfig.json` file that has the correct
  configuration to verify the `index.d.ts` definition file

You can verify the index file by running either `npx tsc` or `yarn tsc`
depending on your choice of package manager.